### PR TITLE
wall_e_interfaces package start, wall_e_control package start, wall_e_audio node

### DIFF
--- a/docker/wall-e-pi-xcompile/README.md
+++ b/docker/wall-e-pi-xcompile/README.md
@@ -26,7 +26,7 @@ cd ${ws}
 # OR
 
 # Use docker to cross compile (runs the above command)
-./src/wall-e/docker/wall-e-pi-xcompile/xcompile ${build-args}
+./src/wall-e/docker/wall-e-pi-xcompile/x-compile ${build-args}
 
 # Could also add an alias to .bashrc, something like:
 alias colcon-wall-e-xcompile='docker run -it -u $(id -u):$(id -g) -v "$(pwd)":/ros_ws "wall-e-pi-xcompile" colcon-aarch64'

--- a/ros/wall_e_control/CMakeLists.txt
+++ b/ros/wall_e_control/CMakeLists.txt
@@ -16,12 +16,31 @@ find_package(wall_e_interfaces REQUIRED)
 
 # Install
 
+# Nodes
+
 # WALL-E audio node
 install(PROGRAMS
   src/nodes/wall_e_audio.py RENAME wall_e_audio
   DESTINATION lib/${PROJECT_NAME}
 )
 
+# Config files
+install(
+  DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# Launch files
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# Sounds
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../web_interface/static/sounds
+  DESTINATION share/${PROJECT_NAME}
+)
 
 
 if(BUILD_TESTING)

--- a/ros/wall_e_control/CMakeLists.txt
+++ b/ros/wall_e_control/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.8)
+project(wall_e_control)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclpy REQUIRED)
+find_package(wall_e_interfaces REQUIRED)
+
+# Build
+
+# Install
+
+# WALL-E audio node
+install(PROGRAMS
+  src/nodes/wall_e_audio.py RENAME wall_e_audio
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros/wall_e_control/config/audio.yaml
+++ b/ros/wall_e_control/config/audio.yaml
@@ -1,0 +1,32 @@
+/**:
+  ros__parameters:
+    default_volume: -1 #TODO change
+    sounds:
+      names: [
+        'ohhh',
+        'raspberry',
+        'tada1',
+        'tada2',
+        'uh-huh',
+        'whistle1',
+        'whistle2',
+        'whoa',
+        'wow',
+        'wall-e1',
+        'wall-e2',
+        'wall-e3',
+      ]
+      files: [
+        'Sound_Ohhh_1850.wav',
+        'Sound_Raspberry_1550.wav',
+        'Sound_Tada_1500.wav',
+        'Sound_Tada-long_10200.wav',
+        'Sound_Uh-Huh_550.wav',
+        'Sound_Whistle-1_1150.wav',
+        'Sound_Whistle-2_550.wav',
+        'Sound_Whoa_1300.wav',
+        'Sound_Wow_810.wav',
+        'Voice_Walle-1_1950.wav',
+        'Voice_Walle-2_3900.wav',
+        'Voice_Walle-3_1700.wav',
+      ]

--- a/ros/wall_e_control/include/wall_e_control/.gitkeep
+++ b/ros/wall_e_control/include/wall_e_control/.gitkeep
@@ -1,0 +1,1 @@
+TODO remove once header files are added

--- a/ros/wall_e_control/launch/wall_e.launch.xml
+++ b/ros/wall_e_control/launch/wall_e.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+  <!-- Launch arguments -->
+  <arg name="audio_config_file" default="$(find-pkg-share wall_e_control)/config/audio.yaml"
+    description="File path of config file for the WALL-E audio node"
+  />
+
+  <!-- Run audio node -->
+  <node pkg="wall_e_control" exec="wall_e_audio" output="screen">
+    <param from="$(var audio_config_file)"/>
+  </node>
+
+</launch>

--- a/ros/wall_e_control/package.xml
+++ b/ros/wall_e_control/package.xml
@@ -13,6 +13,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+
   <depend>wall_e_interfaces</depend>
 
   <export>

--- a/ros/wall_e_control/package.xml
+++ b/ros/wall_e_control/package.xml
@@ -1,23 +1,19 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>wall_e_interfaces</name>
+  <name>wall_e_control</name>
   <version>0.0.0</version>
-  <description>Interfaces for control of the WALL-E robot</description>
+  <description>Hardware control of the WALL-E robot</description>
   <maintainer email="ngmorales97@gmail.com">Nick Morales</maintainer>
   <maintainer email="liz.mtzgr.00@gmail.com">Liz Metzger</maintainer>
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
-
-  <member_of_group>rosidl_interface_packages</member_of_group>
+  <depend>wall_e_interfaces</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros/wall_e_control/src/nodes/wall_e_audio.py
+++ b/ros/wall_e_control/src/nodes/wall_e_audio.py
@@ -1,15 +1,174 @@
 #!/usr/bin/env python3
 
+import subprocess
+
+from ament_index_python.packages import get_package_share_directory
+
 import rclpy
 from rclpy.node import Node
+from rcl_interfaces.msg import ParameterDescriptor
 from wall_e_interfaces.srv import GetSounds, PlaySound, SetVolume
+
+
+SET_VOLUME_COMMAND = ['amixer', '-c0', '-M', '-q', 'sset', 'Headphone']
+PLAY_SOUND_COMMAND = ['ffplay', '-v', '0', '-nodisp', '-autoexit']
+SOUND_DIRECTORY = get_package_share_directory('wall_e_control') + '/sounds/'
 
 class WALLEAudio(Node):
 
     def __init__(self):
         """Initialize the node."""
 
-        super().__init__("wall_e_audio")
+        super().__init__('wall_e_audio')
+
+        # PARAMETERS ---------------------------------------------------------------------------
+        self.declare_parameter(
+            'default_volume',
+            70,
+            ParameterDescriptor(
+                description='Default volume to set on startup (%). If negative, the default will'
+                ' not be set on startup. Otherwise clamped between [0, 100]'
+            )
+        )
+        self.declare_parameter(
+            'sounds.names',
+            ['none'],
+            ParameterDescriptor(
+                description='List of names of sounds that will be used to play them.'
+                + ' Corresponds to sounds.files and lengths must match'
+            )
+        )
+        sound_names = self.get_parameter('sounds.names').get_parameter_value().string_array_value
+        self.declare_parameter(
+            'sounds.files',
+            ['none'],
+            ParameterDescriptor(
+                description='List of files corresponding to the names in sound.names.'
+                + ' These files reside in the wall_e_control package share directory,'
+                + ' "sounds" subdirectory. Length must match sounds.names'
+            )
+        )
+        sound_files = self.get_parameter('sounds.files').get_parameter_value().string_array_value
+
+        if len(sound_names) != len(sound_files):
+            raise RuntimeError(
+                'Sound names and files arrays do not have the same length,'
+                + ' likely due to a malformed parameter file'
+            )
+
+        # Construct sound dictionary, pointing to sound files
+        self.sounds = dict()
+        for i in range(len(sound_names)):
+            self.sounds[sound_names[i]] = SOUND_DIRECTORY + sound_files[i]
+
+        # SERVICES ---------------------------------------------------------------------------
+        self.srv_get_sounds = self.create_service(
+            GetSounds,
+            'get_sounds',
+            self.srv_get_sounds_callback
+        )
+        self.srv_play_sound = self.create_service(
+            PlaySound,
+            'play_sound',
+            self.srv_play_sound_callback
+        )
+        self.srv_set_volume = self.create_service(
+            SetVolume,
+            'set_volume',
+            self.srv_set_volume_callback
+        )
+
+        # set the default volume
+        self.set_volume(self.get_parameter('default_volume').get_parameter_value().integer_value)
+
+        self.get_logger().info(f'{self.get_fully_qualified_name()} node started')
+
+    def set_volume(self, volume: int):
+        """
+        Set volume to the specified integer percentage.
+
+        Args:
+            volume (int): percentage volumte to set
+        """
+
+        if volume < 0:
+            return
+
+        # clamp volume to [0, 100]
+        volume = max(0, min(100, volume))
+
+        cmd = SET_VOLUME_COMMAND + [f'{volume}%']
+
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        self.get_logger().info(f'Volume set to {volume}%')
+
+    def get_available_sounds(self):
+        """Compile list of available sounds."""
+
+        return [name for name in self.sounds.keys()]
+
+    def srv_get_sounds_callback(self, request, response):
+        """
+        Get a list of available sounds by name.
+
+        Args:
+            request (GetSounds.Request): service request, empty
+            response (GetSounds.Response): service response, contains list of sound names
+
+        Returns:
+            response: filled out response
+        """
+
+        response.sounds = self.get_available_sounds()
+
+        self.get_logger().info(f'Available sounds: {response.sounds}')
+
+        return response
+
+    def srv_play_sound_callback(self, request, response):
+        """
+        Play a configured sound.
+
+        Args:
+            request (PlaySound.Request): service request with name of sound to play
+            response (PlaySound.Response): service response, indicating success/failure
+
+        Returns:
+            response: filled out response
+        """
+
+        if request.sound not in self.sounds:
+            self.get_logger().error(
+                f'"{request.sound}" not available as a configured sound.'
+                + f' Available sounds: {self.get_available_sounds()}'
+            )
+            response.success = False
+            return response
+
+        cmd = PLAY_SOUND_COMMAND + [self.sounds[request.sound]]
+
+        subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        response.success = True
+
+        return response
+
+    def srv_set_volume_callback(self, request, response):
+        """
+        Set the volume via the service
+
+        Args:
+            request (SetVolume.Request): service request, has volume argument
+            response (SetVolume.Response): service response, empty
+
+        Returns:
+            response: empty response
+        """
+
+        self.set_volume(request.volume)
+
+        return response
 
 
 def main(args=None):

--- a/ros/wall_e_control/src/nodes/wall_e_audio.py
+++ b/ros/wall_e_control/src/nodes/wall_e_audio.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import rclpy
+from rclpy.node import Node
+from wall_e_interfaces.srv import GetSounds, PlaySound, SetVolume
+
+class WALLEAudio(Node):
+
+    def __init__(self):
+        """Initialize the node."""
+
+        super().__init__("wall_e_audio")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = WALLEAudio()
+    rclpy.spin(node)
+    rclpy.shutdown()
+
+if __name__ == '__main__':
+    main()

--- a/ros/wall_e_control/src/nodes/wall_e_audio.py
+++ b/ros/wall_e_control/src/nodes/wall_e_audio.py
@@ -24,7 +24,7 @@ class WALLEAudio(Node):
         # PARAMETERS ---------------------------------------------------------------------------
         self.declare_parameter(
             'default_volume',
-            70,
+            100,
             ParameterDescriptor(
                 description='Default volume to set on startup (%). If negative, the default will'
                 ' not be set on startup. Otherwise clamped between [0, 100]'

--- a/ros/wall_e_interfaces/CMakeLists.txt
+++ b/ros/wall_e_interfaces/CMakeLists.txt
@@ -15,7 +15,7 @@ file(GLOB_RECURSE SERVICES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} srv/*)
 rosidl_generate_interfaces(${PROJECT_NAME}
   # ${MESSAGES} TODO add
   ${SERVICES}
-  DEPENDENCIES
+  # DEPENDENCIES
   # TODO add
 )
 

--- a/ros/wall_e_interfaces/CMakeLists.txt
+++ b/ros/wall_e_interfaces/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.8)
+project(wall_e_interfaces)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+# file(GLOB_RECURSE MESSAGES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} msg/*) TODO add
+file(GLOB_RECURSE SERVICES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} srv/*)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  # ${MESSAGES} TODO add
+  ${SERVICES}
+  DEPENDENCIES
+  # TODO add
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ros/wall_e_interfaces/package.xml
+++ b/ros/wall_e_interfaces/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>wall_e_interfaces</name>
+  <version>0.0.0</version>
+  <description>Interfaces for control of the WALL-E robot</description>
+  <maintainer email="ngmorales97@gmail.com">ngm</maintainer>
+  <maintainer email="liz.mtzgr.00@gmail.com">Liz Metzger</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros/wall_e_interfaces/srv/audio/GetSounds.srv
+++ b/ros/wall_e_interfaces/srv/audio/GetSounds.srv
@@ -1,0 +1,10 @@
+#
+# Get a list of the names of available preconfigured sounds
+#
+
+# REQUEST -------------------------------------------------------------------------------------
+---
+# RESPONSE -------------------------------------------------------------------------------------
+
+# List of the names of available preconfigured sounds
+string[] sounds

--- a/ros/wall_e_interfaces/srv/audio/PlaySound.srv
+++ b/ros/wall_e_interfaces/srv/audio/PlaySound.srv
@@ -1,0 +1,13 @@
+#
+# Play a preconfigured sound, by the configured name
+#
+
+# REQUEST -------------------------------------------------------------------------------------
+
+# Name of sound to play
+string sound
+---
+# RESPONSE -------------------------------------------------------------------------------------
+
+# True if successfully played
+bool success

--- a/ros/wall_e_interfaces/srv/audio/SetVolume.srv
+++ b/ros/wall_e_interfaces/srv/audio/SetVolume.srv
@@ -1,0 +1,11 @@
+#
+# Set the speaker volume by percentage
+#
+
+# REQUEST -------------------------------------------------------------------------------------
+
+# Volume to be set, will be clamped between 0 and 100
+uint8 volume
+
+---
+# RESPONSE -------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds ROS packages:
* `wall_e_interfaces` - ROS interfaces for WALL-E control
* `wall_e_control` - low level ROS hardware control of WALL-E (motors, audio, display, etc)

Adds the audio node `wall_e_audio` which controls playing sounds over the headphone jack.